### PR TITLE
MDL-61302 policy: Fix returnurl param issue

### DIFF
--- a/admin/tool/policy/classes/output/guestconsent.php
+++ b/admin/tool/policy/classes/output/guestconsent.php
@@ -63,6 +63,7 @@ class guestconsent implements renderable, templatable {
                 $data->returnurl = $returnurl;
             }
         }
+        $data->returnurl = urlencode($data->returnurl);
 
         $policies = \tool_policy\api::list_policies(null, true, api::AUDIENCE_GUESTS);
         $data->policies = array_values($policies);

--- a/admin/tool/policy/templates/guestconsent.mustache
+++ b/admin/tool/policy/templates/guestconsent.mustache
@@ -39,7 +39,7 @@ require(['jquery', 'tool_policy/jquery-eu-cookie-law-popup', 'tool_policy/policy
                 var textmessage = "{{# str }} guestconsentmessage, tool_policy {{/ str }}" +
                    "<ul>{{#policies}}" +
                    "<li>" +
-                   "<a href=\"{{pluginbaseurl}}/view.php?policyid={{id}}{{#returnurl}}&returnurl={{.}}{{/returnurl}}\" "+
+                   "<a href=\"{{pluginbaseurl}}/view.php?policyid={{id}}{{#returnurl}}&amp;returnurl={{.}}{{/returnurl}}\" "+
                    "   data-action=\"view\" data-versionid=\"{{currentversionid}}\" data-behalfid=\"1\" >" +
                    "{{name}}" +
                    "</a>" +


### PR DESCRIPTION
Patch to avoid problem if returnurl param contains any & character.