### PR TITLE
Remove /admin reference and add extra call to set_popup_notification_allowed

### DIFF
--- a/admin/tool/policy/classes/output/guestconsent.php
+++ b/admin/tool/policy/classes/output/guestconsent.php
@@ -53,7 +53,7 @@ class guestconsent implements renderable, templatable {
 
         $data = (object) [];
         $data->pluginbaseurl = (new moodle_url('/admin/tool/policy'))->out(true);
-        if (strpos(qualified_me(), 'admin/tool/policy/view.php') === false) {
+        if (strpos(qualified_me(), '/tool/policy/view.php') === false) {
             // Current page is not a policy doc, so returnurl parameter will be it.
             $data->returnurl = qualified_me();
         } else {

--- a/admin/tool/policy/classes/output/page_viewdoc.php
+++ b/admin/tool/policy/classes/output/page_viewdoc.php
@@ -98,7 +98,7 @@ class page_viewdoc implements renderable, templatable {
      * Sets up the global $PAGE and performs the access checks.
      */
     protected function prepare_global_page_access() {
-        global $CFG, $PAGE, $SITE;
+        global $CFG, $PAGE, $SITE, $USER;
 
         $myurl = new moodle_url('/admin/tool/policy/view.php', [
             'policyid' => $this->policy->policyid,
@@ -116,10 +116,12 @@ class page_viewdoc implements renderable, templatable {
             require_capability('tool/policy:managedocs', context_system::instance());
             $PAGE->navbar->add(format_string($this->policy->name),
                 new moodle_url('/admin/tool/policy/managedocs.php', ['id' => $this->policy->policyid]));
-
         } else {
             if (!api::is_public($this->policy)) {
                 require_login();
+            } else if (isguestuser() || empty($USER->id) || !$USER->policyagreed) {
+                // Disable notifications for new users, guests or users who haven't agreed to the policies.
+                $PAGE->set_popup_notification_allowed(false);
             }
             $PAGE->set_context(context_system::instance());
             $PAGE->set_pagelayout('standard');


### PR DESCRIPTION
- Removed /admin reference (to avoid problems if users are using $CFG->admin).
- Added extra call to $PAGE->set_popup_notification_allowed(false) in the page for viewing policies. Although, at the moment, it's ignored because of https://tracker.moodle.org/browse/MDL-61516